### PR TITLE
Cleaner screenshot handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+screenshots/*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GREP ?=.
 
 test: node_modules
-	@rm -rf /tmp/niffy
+	@rm -rf ./screenshots
 	@node_modules/.bin/mocha --harmony --grep "$(GREP)"
 
 node_modules: package.json

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ test: node_modules
 	@rm -rf ./screenshots
 	@node_modules/.bin/mocha --harmony --grep "$(GREP)"
 
+clean: screenshots
+		@rm -rf ./screenshots
+		
 node_modules: package.json
 	@npm install
 

--- a/index.js
+++ b/index.js
@@ -183,7 +183,15 @@ Niffy.prototype.stopProfile = function (name) {
  */
 
 function imgfilepath(name, path) {
-  var filepath = '/tmp/niffy' + path;
+
+  var folderExtension;
+  if (path === '/') {
+    folderExtension = 'homepage';
+  } else {
+    folderExtension = path.substring(1).replace('/', '-');
+  }
+
+  var filepath = './screenshots/' + folderExtension;
   if (filepath.slice(-1) !== '/') filepath += '/';
   mkdirp(filepath);
   return (filepath + name + '.png');

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ function imgfilepath(name, path) {
   if (path === '/') {
     folderExtension = 'homepage';
   } else {
-    folderExtension = path.substring(1).replace('/', '-');
+    folderExtension = path.substring(1);
   }
 
   var filepath = './screenshots/' + folderExtension;


### PR DESCRIPTION
**Fix**
Screenshots were not being saved properly in my clone of the repo, and because all screenshots had the same names (base, test, diff), they were overwriting previous tests' screenshots. 

This change nests screenshots within a larger screenshot folder, allowing for clean and easy reference. It's a small fix.

Any feedback would be appreciated.