### PR TITLE
When writing the diff file, Niffy does not wait for stream to close

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -33,7 +33,7 @@ function* diff(pathA, pathB, pathDiff) {
 
   debug('finished diffing imgs %s', new Date());
 
-  writePNG(png, pathDiff);
+  yield thunkify(writePNG)(png, pathDiff);
 
   debug('finished img diffing %s', new Date());
 
@@ -64,10 +64,13 @@ function readPNG(path, callback) {
  * @param {String} path
  */
 
-function writePNG(png, path) {
+function writePNG(png, path, callback) {
   png
     .pack()
-    .pipe(fs.createWriteStream(path));
+    .pipe(fs.createWriteStream(path))
+    .on('close', function() {
+      callback(null, this);
+    });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "defaults": "^1.0.2",
     "mkdirp": "^0.5.1",
     "nightmare": "^2.0.3",
-    "pngjs": "^3.0.1",
+    "pngjs": "^3.3.1",
     "sprintf-js": "^1.0.3",
     "thunkify": "^2.1.2",
     "vo": "^1.0.3"


### PR DESCRIPTION
We encountered this issue while adding an upload to S3 to our **after** phase.
The file uploaded to S3 contained partial data; indicating that there was multiple processes competing to write and read the file.
Fix is a simple on close handler used with thunkify.
We also bumped the version of pngjs.

Let us know what you think.

note: potential bug/omission found in pngjs. Will be filed.
https://github.com/lukeapage/pngjs/blob/master/lib/png.js#L43

